### PR TITLE
Fixes a mismatch in terms for how strings are categorised ("uris" vs …

### DIFF
--- a/src/sparql/query_template.sparql
+++ b/src/sparql/query_template.sparql
@@ -19,7 +19,7 @@ SELECT DISTINCT ?SearchTerm ?MatchURI (SAMPLE(?MatchPropertyAll) AS ?MatchProper
   {%- else %}
     {% set predicate = predicate %}
   {%- endif %}
-  (?MatchURI ?Weight ?MatchTerm ?graph ?MatchProp) text:query ({{ predicate }} ?EscapedSearchTerm 5 ) .
+  (?MatchURI ?Weight ?MatchTerm ?graph ?MatchProp) text:query ({{ predicate }} ?EscapedSearchTerm 10 ) .
     GRAPH ?g {?MatchURI ?p ?o}
     {%- if theme_uris %}
       VALUES ?theme_uri {

--- a/src/sparql/query_template.sparql
+++ b/src/sparql/query_template.sparql
@@ -19,7 +19,7 @@ SELECT DISTINCT ?SearchTerm ?MatchURI (SAMPLE(?MatchPropertyAll) AS ?MatchProper
   {%- else %}
     {% set predicate = predicate %}
   {%- endif %}
-  (?MatchURI ?Weight ?MatchTerm ?graph ?MatchProp) text:query ({{ predicate }} ?EscapedSearchTerm 10 ) .
+  (?MatchURI ?Weight ?MatchTerm ?graph ?MatchProp) text:query ({{ predicate }} ?EscapedSearchTerm 5 ) .
     GRAPH ?g {?MatchURI ?p ?o}
     {%- if theme_uris %}
       VALUES ?theme_uri {

--- a/src/xml_extract_all.py
+++ b/src/xml_extract_all.py
@@ -23,20 +23,20 @@ def extract_full_xml(xml_string):
     ]
     variants = []
     for gt2t in types_to_text:
-        if gt2t["guessed_type"] == "URI":
+        if gt2t["guessed_type"] == "uris":
             http_https_variant = get_http_https_variant(gt2t["text"])
             if http_https_variant:
-                variants.append({"guessed_type": "URI", "text": http_https_variant})
+                variants.append({"guessed_type": "uris", "text": http_https_variant})
                 trailing_slash_on_http_variant = get_trailing_slash_variant(
                     http_https_variant
                 )
                 if trailing_slash_on_http_variant:
                     variants.append(
-                        {"guessed_type": "URI", "text": trailing_slash_on_http_variant}
+                        {"guessed_type": "uris", "text": trailing_slash_on_http_variant}
                     )
             trailing_slash_variant = get_trailing_slash_variant(gt2t["text"])
             if trailing_slash_variant:
-                variants.append({"guessed_type": "URI", "text": trailing_slash_variant})
+                variants.append({"guessed_type": "uris", "text": trailing_slash_variant})
     types_to_text.extend(variants)
     return types_to_text
 

--- a/tests/test_quack.py
+++ b/tests/test_quack.py
@@ -25,6 +25,7 @@ from src.string_functions import quack_analyser
         ("SDN::L10", "identifier"),  # real example
         ("SDN:L10", "identifier"),  # variation
         ("lithology", "string"),
+        ("SDN:L05::60", "identifier")
     ],
 )
 def test_quack_analyser(input_str, expected):
@@ -32,3 +33,5 @@ def test_quack_analyser(input_str, expected):
     assert (
         result == expected
     ), f"Expected {expected} but got {result} for input {input_str}"
+
+#TODO add more identifier tests for full identifiers


### PR DESCRIPTION
…"URI") which was preventing http/https and trailing slash variants from being added when using the Full XML extraction method.

@alko-k this should solve the trailing slash variant issue - I cannot find a specific record to validate this end to end but I can see the variants getting generated now.

@matcor-bodc this is a change to fix a bug where "trailing slash" variants were not being included as search terms - I'll leave it with you or others to discuss with Alex / Gwen as to urgency/priority.

I have tested this locally without issue. Unfortunately I do not have the zappa config on this laptop (it is not in version control as it has credentials in it), so I cannot update the demo instance we have . 

